### PR TITLE
Added support for Branch Coverage measuring in CompareHands.getMostCommonSuit()

### DIFF
--- a/src/edu/ucsb/cs56/projects/games/poker/CompareHands.java
+++ b/src/edu/ucsb/cs56/projects/games/poker/CompareHands.java
@@ -540,40 +540,54 @@ public class CompareHands implements Serializable{
      * @return char representing the suit
      */
     private char getMostCommonSuit(ArrayList<Card> hand) {
+    	TestBench.coverage.put("getMostCommonSuit1", true);
         int heartsCounter = 0;
         int diamondsCounter = 0;
         int spadesCounter = 0;
         int clubsCounter = 0;
 
         for (int i = 0; i < hand.size(); i++) {
+        	TestBench.coverage.put("getMostCommonSuit2", true);
             switch (hand.get(i).getSuit().charAt(0)) {
                 case 'H':
+                	TestBench.coverage.put("getMostCommonSuit3", true);
                     heartsCounter++;
                     break;
                 case 'D':
+                	TestBench.coverage.put("getMostCommonSuit4", true);
                     diamondsCounter++;
                     break;
                 case 'S':
+                	TestBench.coverage.put("getMostCommonSuit5", true);
                     spadesCounter++;
                     break;
                 case 'C':
+                	TestBench.coverage.put("getMostCommonSuit6", true);
                     clubsCounter++;
                     break;
+                default:
+                	TestBench.coverage.put("getMostCommonSuit7", true);
+                	break;
             }
         }
 
         int max_occurrences = Math.max(heartsCounter, Math.max(diamondsCounter, Math.max(spadesCounter, clubsCounter)));
 
         if (max_occurrences == heartsCounter) {
+        	TestBench.coverage.put("getMostCommonSuit8", true);
             return 'H';
         }
         else if (max_occurrences == diamondsCounter) {
+        	TestBench.coverage.put("getMostCommonSuit9", true);
             return 'D';
         }
         else if (max_occurrences == spadesCounter) {
+        	TestBench.coverage.put("getMostCommonSuit10", true);
             return 'S';
-        }
-        return 'C';
+        } else {
+        	TestBench.coverage.put("getMostCommonSuit11", true);
+        	return 'C';        	
+        }        
     }
 
     /**

--- a/src/edu/ucsb/cs56/projects/games/poker/CompareHands.java
+++ b/src/edu/ucsb/cs56/projects/games/poker/CompareHands.java
@@ -539,7 +539,7 @@ public class CompareHands implements Serializable{
      * Returns suit occurring the most in a hand
      * @return char representing the suit
      */
-    private char getMostCommonSuit(ArrayList<Card> hand) {
+    char getMostCommonSuit(ArrayList<Card> hand) {
     	TestBench.coverage.put("getMostCommonSuit1", true);
         int heartsCounter = 0;
         int diamondsCounter = 0;

--- a/src/edu/ucsb/cs56/projects/games/poker/CompareHandsTest.java
+++ b/src/edu/ucsb/cs56/projects/games/poker/CompareHandsTest.java
@@ -455,4 +455,64 @@ import org.junit.Test;
 
         assertEquals(1, comparingHands.compareHands());
     }
+    
+    /**
+     * Tests that getMostCommonSuit() recognises if diamond is the most common suite of the hand.
+     */
+    @Test
+    public void testGetMostCommonSuitDiamond() {
+    	table = new TableCards(sevenClub, tenDiamond, threeHeart, sixDiamond, fourClub);
+        hand1 = new Hand(aceHeart, twoSpade);
+        player1 = new User(hand1);
+        hand2 = new Hand(nineHeart, jackDiamond);
+        player2 = new User(hand2);
+        comparingHands = new CompareHands(player1, player2, table);
+        
+    	ArrayList<Card> cards = new ArrayList<Card>();
+    	cards.add(aceDiamond);
+    	cards.add(kingDiamond);
+    	cards.add(queenDiamond);
+    	cards.add(jackDiamond);
+    	assertEquals(comparingHands.getMostCommonSuit(cards), 'D');
+    }
+    
+    /**
+     * Tests that getMostCommonSuit() recognises if spades is the most common suite of the hand.
+     */
+    @Test
+    public void testGetMostCommonSuitSpades() {
+    	table = new TableCards(sevenClub, tenDiamond, threeHeart, sixDiamond, fourClub);
+        hand1 = new Hand(aceHeart, twoSpade);
+        player1 = new User(hand1);
+        hand2 = new Hand(nineHeart, jackDiamond);
+        player2 = new User(hand2);
+        comparingHands = new CompareHands(player1, player2, table);
+        
+    	ArrayList<Card> cards = new ArrayList<Card>();
+    	cards.add(aceSpade);
+    	cards.add(kingSpade);
+    	cards.add(queenSpade);
+    	cards.add(jackSpade);
+    	assertEquals(comparingHands.getMostCommonSuit(cards), 'S');
+    }
+    
+    /**
+     * Tests that getMostCommonSuit() recognises if clubs is the most common suite of the hand.
+     */
+    @Test
+    public void testGetMostCommonSuitClubs() {
+    	table = new TableCards(sevenClub, tenDiamond, threeHeart, sixDiamond, fourClub);
+        hand1 = new Hand(aceHeart, twoSpade);
+        player1 = new User(hand1);
+        hand2 = new Hand(nineHeart, jackDiamond);
+        player2 = new User(hand2);
+        comparingHands = new CompareHands(player1, player2, table);
+        
+    	ArrayList<Card> cards = new ArrayList<Card>();
+    	cards.add(aceClub);
+    	cards.add(kingClub);
+    	cards.add(queenClub);
+    	cards.add(jackClub);
+    	assertEquals(comparingHands.getMostCommonSuit(cards), 'C');
+    }
 }

--- a/src/edu/ucsb/cs56/projects/games/poker/PokerMain.java
+++ b/src/edu/ucsb/cs56/projects/games/poker/PokerMain.java
@@ -52,6 +52,7 @@ public class PokerMain {
     		TestBench.SetupCoverageTracking();
         PokerMain start = new PokerMain();
         start.go();
+        TestBench.AnalyzeCoverage();
     }    
 
     /**

--- a/src/edu/ucsb/cs56/projects/games/poker/PokerMain.java
+++ b/src/edu/ucsb/cs56/projects/games/poker/PokerMain.java
@@ -49,6 +49,7 @@ public class PokerMain {
      * Runs the application
      */
     public static void main(String[] args) {
+    		TestBench.SetupCoverageTracking();
         PokerMain start = new PokerMain();
         start.go();
     }    

--- a/src/edu/ucsb/cs56/projects/games/poker/PokerMain.java
+++ b/src/edu/ucsb/cs56/projects/games/poker/PokerMain.java
@@ -49,7 +49,7 @@ public class PokerMain {
      * Runs the application
      */
     public static void main(String[] args) {
-    		TestBench.SetupCoverageTracking();
+    	TestBench.SetupCoverageTracking();
         PokerMain start = new PokerMain();
         start.go();
         TestBench.AnalyzeCoverage();

--- a/src/edu/ucsb/cs56/projects/games/poker/TestBench.java
+++ b/src/edu/ucsb/cs56/projects/games/poker/TestBench.java
@@ -1,5 +1,13 @@
 package edu.ucsb.cs56.projects.games.poker;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
+/**
+ * This class holds all data structures and functions
+ * relating to our DIY branch coverage tracker
+ * @author danhemgren
+ *
+ */
 
 public class TestBench {
 	public static HashMap<String, Boolean> coverage;
@@ -17,5 +25,24 @@ public class TestBench {
 		coverage.put("compareHands9", false);
 		coverage.put("compareHands10", false);
 		coverage.put("compareHands11", false);
+	}
+	
+	public static void AnalyzeCoverage() {
+		Collection<Boolean> values = coverage.values();
+		int totalNumberOfBranches = values.size();
+		if(totalNumberOfBranches < 1) {
+			System.out.println("No branches have been registered, aborting...");
+			return;
+		}
+		int traversedBranches = 0;
+		Iterator it = values.iterator();
+		while(it.hasNext()) {
+			Boolean val = (Boolean) it.next();
+			if(val == true) {
+				traversedBranches++;
+			}
+		}
+		double res = ((double)traversedBranches / (double)totalNumberOfBranches)*100;
+		System.out.println("Total branch coverage is " + res + "%");
 	}
 }

--- a/src/edu/ucsb/cs56/projects/games/poker/TestBench.java
+++ b/src/edu/ucsb/cs56/projects/games/poker/TestBench.java
@@ -1,0 +1,6 @@
+package edu.ucsb.cs56.projects.games.poker;
+import java.util.HashMap;
+
+public class TestBench {
+	public static HashMap<String, Boolean> coverage;
+}

--- a/src/edu/ucsb/cs56/projects/games/poker/TestBench.java
+++ b/src/edu/ucsb/cs56/projects/games/poker/TestBench.java
@@ -12,6 +12,12 @@ import java.util.Iterator;
 public class TestBench {
 	public static HashMap<String, Boolean> coverage;
 	
+	/**
+	 * Initialize the data structure used for 
+	 * DIY branch coverage. All branches needs
+	 * to be registered here as false to provide
+	 * correct ratio in AnalyzeCoverage
+	 */
 	public static void SetupCoverageTracking() {
 		coverage = new HashMap<String, Boolean>();
 		coverage.put("compareHands1", false);
@@ -27,6 +33,10 @@ public class TestBench {
 		coverage.put("compareHands11", false);
 	}
 	
+	/**
+	 * Iterate through registered branches 
+	 * and calculate ratio of traversed branches. 
+	 */
 	public static void AnalyzeCoverage() {
 		Collection<Boolean> values = coverage.values();
 		int totalNumberOfBranches = values.size();

--- a/src/edu/ucsb/cs56/projects/games/poker/TestBench.java
+++ b/src/edu/ucsb/cs56/projects/games/poker/TestBench.java
@@ -3,4 +3,19 @@ import java.util.HashMap;
 
 public class TestBench {
 	public static HashMap<String, Boolean> coverage;
+	
+	public static void SetupCoverageTracking() {
+		coverage = new HashMap<String, Boolean>();
+		coverage.put("compareHands1", false);
+		coverage.put("compareHands2", false);
+		coverage.put("compareHands3", false);
+		coverage.put("compareHands4", false);
+		coverage.put("compareHands5", false);
+		coverage.put("compareHands6", false);
+		coverage.put("compareHands7", false);
+		coverage.put("compareHands8", false);
+		coverage.put("compareHands9", false);
+		coverage.put("compareHands10", false);
+		coverage.put("compareHands11", false);
+	}
 }

--- a/src/edu/ucsb/cs56/projects/games/poker/TestBench.java
+++ b/src/edu/ucsb/cs56/projects/games/poker/TestBench.java
@@ -31,6 +31,17 @@ public class TestBench {
 		coverage.put("compareHands9", false);
 		coverage.put("compareHands10", false);
 		coverage.put("compareHands11", false);
+		coverage.put("getMostCommonSuit1", false);
+		coverage.put("getMostCommonSuit2", false);
+		coverage.put("getMostCommonSuit3", false);
+		coverage.put("getMostCommonSuit4", false);
+		coverage.put("getMostCommonSuit5", false);
+		coverage.put("getMostCommonSuit6", false);
+		coverage.put("getMostCommonSuit7", false);
+		coverage.put("getMostCommonSuit8", false);
+		coverage.put("getMostCommonSuit9", false);
+		coverage.put("getMostCommonSuit10", false);
+		coverage.put("getMostCommonSuit11", false);
 	}
 	
 	/**


### PR DESCRIPTION
Added Branch Coverage measuring in CompareHands.getMostCommonSuit() that sets the values of the keys of the branch flags to true when covered by tests. solves #7 

